### PR TITLE
Update main.scss

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -817,6 +817,8 @@ $baseurl: '{{ site.baseurl }}/images';
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		user-select: none;
+		-webkit-user-select: none;
 
 		&:hover {
 			background-color: _palette(border-bg);
@@ -1313,6 +1315,8 @@ $baseurl: '{{ site.baseurl }}/images';
 					outline: 0;
 					text-decoration: none;
 					text-transform: uppercase;
+					user-select: none;
+					-webkit-user-select: none;
 
 					@include breakpoint(small) {
 						line-height: 3em;
@@ -1367,6 +1371,11 @@ $baseurl: '{{ site.baseurl }}/images';
 		top: 0;
 		width: 100%;
 		z-index: _misc(z-index-base);
+
+		a {
+			user-select: none;
+			-webkit-user-select: none;
+		}
 
 		h1 {
 			@include vendor('transition', 'opacity #{_duration(transitions)} ease');
@@ -1512,6 +1521,8 @@ $baseurl: '{{ site.baseurl }}/images';
 			text-transform: uppercase;
 			width: 16em;
 			z-index: 1;
+			user-select: none;
+			-webkit-user-select: none;
 
 			&:after {
 				background-image: url('images/arrow.svg');


### PR DESCRIPTION
Removed the option to select text on buttons.

This is a simple change. Particularly, I don't think it's very nice when the text inside buttons is "selectable" and I try to remove this feature in every website I make. I simply added `user-select: none` and `-webkit-user-select: none` to some of the `main.scss` elements to accomplish it.

References:
https://developer.mozilla.org/en-US/docs/Web/CSS/user-select